### PR TITLE
SHDW overloades logfile

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -235,7 +235,7 @@ class MQTTClient {
    */
   destroy() {
     if (this.active) {
-      this.adapter.log.info('Destroy ' + this.getName());
+      this.adapter.log.debug('Destroy ' + this.getName());
       this.active = false;
       clearTimeout(this.timerid);
       clearInterval(this.resendid);
@@ -886,7 +886,7 @@ class MQTTServer {
     this.server.on('connection', (stream) => {
       let client = new MQTTClient(this.adapter, this.objectHelper, this.eventEmitter, stream);
       stream.on('timeout', () => {
-        this.adapter.log.info('Server Timeout for ' + stream.remoteAddress + ' (' + client.getName() + ')');
+        this.adapter.log.debug('Server Timeout for ' + stream.remoteAddress + ' (' + client.getName() + ')');
         client.destroy();
         stream.destroy();
       });


### PR DESCRIPTION
SHDWs are entering sleep mode and reconnects in MQTT mode for sending a next status. For each sleepmode entering and awaking again log messages are send like
```
(1587) Destroy 10.0.0.201 (shellydw / shellydw-F02FAE / SHDW-1#XXXXXX#1)
(1587) Server Timeout for 10.0.0.201 (10.0.0.201 (shellydw / shellydw-XXXXXX / SHDW-1#FXXXXXX#1))
```
I suggest to switch for this two messages to debug-mode instead off info-mode.