### PR TITLE
Update mqtt.js

### DIFF
--- a/lib/mqtt.js
+++ b/lib/mqtt.js
@@ -773,8 +773,8 @@ class MQTTClient {
     this.client.on('connect', async (packet) => {
       this.packet = packet;
       if (this.deviceExist()) {
-        if (packet.username === this.adapter.config.mqttusername && packet.password.toString() === this.adapter.config.mqttpassword) {
-          // check for existing instnaces
+        if (packet.username === this.adapter.config.mqttusername && packet.password !== undefined && packet.password.toString() === this.adapter.config.mqttpassword) {
+          // check for existing instances
           MQTTClient._registerRun(this);
           this.adapter.log.info('Shelly device ' + this.getName() + ' with MQTT connected!');
           // Letzer Wille speichern
@@ -796,7 +796,7 @@ class MQTTClient {
           this.client.connack({ returnCode: 4 });
         }
       } else {
-        this.adapter.log.error('Shelly Device unknown, configuratin for Shelly device ' + this.getName() + ' for MQTT does not exist!');
+        this.adapter.log.error('Shelly Device unknown, configuration for Shelly device ' + this.getName() + ' for MQTT does not exist!');
         this.client.connack({ returnCode: 4 });
       }
     });


### PR DESCRIPTION
I've added a shelly to my setup, and somehow the shelly didn't save or at least didn't send the MQTT password to the broker, resulting in the following error. So it would be useful to prevent crashes and also log wrong auth info. 

```
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.EventEmitter.emit (domain.js:448:20)
-- | -- | -- | --
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.emit (events.js:198:13)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Object.onceWrapper (events.js:286:20)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.<anonymous> (/opt/iobroker/node_modules/mqtt-connection/connection.js:53:12)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.EventEmitter.emit (domain.js:448:20)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.emit (events.js:198:13)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.emitPacket (/opt/iobroker/node_modules/mqtt-connection/connection.js:10:8)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.EventEmitter.emit (domain.js:448:20)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.emit (events.js:198:13)
shelly.0 | 2020-10-22 17:08:29.907 | error | at Connection.client.on (/opt/iobroker/node_modules/iobroker.shelly/lib/mqtt.js:715:85)
shelly.0 | 2020-10-22 17:08:29.907 | error | (11465) Exception: TypeError: Cannot read property 'toString' of undefined
```