### PR TITLE
Fix #284 : no negative temperature values over MQTT

### DIFF
--- a/lib/devices/shelly1.js
+++ b/lib/devices/shelly1.js
@@ -286,7 +286,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -303,7 +303,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -320,7 +320,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -337,7 +337,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -354,7 +354,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -371,7 +371,7 @@ let shelly1 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',

--- a/lib/devices/shelly1l.js
+++ b/lib/devices/shelly1l.js
@@ -481,7 +481,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -499,7 +499,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -517,7 +517,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -535,7 +535,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -553,7 +553,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -571,7 +571,7 @@ let shelly1l = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',

--- a/lib/devices/shelly1pm.js
+++ b/lib/devices/shelly1pm.js
@@ -436,7 +436,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -454,7 +454,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -472,7 +472,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -490,7 +490,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -508,7 +508,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -526,7 +526,7 @@ let shelly1pm = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',

--- a/lib/devices/shellyswitch25.js
+++ b/lib/devices/shellyswitch25.js
@@ -930,7 +930,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -948,7 +948,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -966,7 +966,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -984,7 +984,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -1002,7 +1002,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -1020,7 +1020,7 @@ let shellyswitch25 = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature_f/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',

--- a/lib/devices/shellyuni.js
+++ b/lib/devices/shellyuni.js
@@ -583,7 +583,7 @@ let shellyuni = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/0',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -603,7 +603,7 @@ let shellyuni = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/1',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -623,7 +623,7 @@ let shellyuni = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/2',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -643,7 +643,7 @@ let shellyuni = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/3',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',
@@ -663,7 +663,7 @@ let shellyuni = {
     },
     mqtt: {
       mqtt_publish: 'shellies/<mqttprefix>/ext_temperature/4',
-      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.]/g, ''); }
+      mqtt_publish_funct: (value) => { return String(value).replace(/[^0-9\.-]/g, ''); }
     },
     common: {
       'name': 'External Temperature',


### PR DESCRIPTION
The current Regex removed every non-digit and non-`.` character, i.e. also the negative (-) sign. This PR fixes issue #284 and allows negative temperature values over MQTT. I didn't change the Regex for humidity, because it will never have a negative value.

Affected devices: 1, 1L, 1PM, 2.5, UNI