### PR TITLE
Added "power" and "energy" suppport. Solves issue #298

### DIFF
--- a/lib/devices/shellyvintage.js
+++ b/lib/devices/shellyvintage.js
@@ -104,6 +104,44 @@ let shellyvintage = {
       'min': 0,
       'max': 100
     }
+  },
+  'lights.power': {
+    coap: {
+      coap_publish: '4101', // CoAP >= FW 1.8
+      coap_publish_funct: (value) => { return value; },
+    },
+    mqtt: {
+      mqtt_publish: 'shellies/<mqttprefix>/light/0/power',
+      mqtt_publish_funct: (value) => { return value; },
+    },
+    common: {
+      'name': 'Power',
+      'type': 'number',
+      'role': 'value.power',
+      'read': true,
+      'write': false,
+      'def': 0,
+      'unit': 'W'
+    }
+  },
+  'lights.energy': {
+    coap: {
+      coap_publish: '4103', // CoAP >= FW 1.8
+      coap_publish_funct: (value) => { return value; },
+    },
+    mqtt: {
+      mqtt_publish: 'shellies/<mqttprefix>/light/0/energy',
+      mqtt_publish_funct: (value) => { return value; },
+    },
+    common: {
+      'name': 'Energy',
+      'type': 'number',
+      'role': 'value.power',
+      'read': true,
+      'write': false,
+      'def': 0,
+      'unit': 'Wmin'
+    }
   }
 };
 


### PR DESCRIPTION
Power and Energy are now supported by adding 2 new data points accessing the CoAP ids "4101" and "4103" or the MQTT ids "../light/0/power" and "../lights/0/energy".
Solves issue #298. Issue #297 has been solved already.